### PR TITLE
Changed golang package source from debian packaging to 1.2.2 binary tar ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,25 +11,31 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
 
-# install deps
-RUN apt-get install -y wget git golang ruby ruby-dev rubygems irb ri rdoc build-essential libopenssl-ruby1.9.1 libssl-dev zlib1g-dev
+# install deps (do not install go via debian packages)
+RUN apt-get install -y wget git ruby ruby-dev rubygems irb ri rdoc build-essential libopenssl-ruby1.9.1 libssl-dev zlib1g-dev 
+
+#Get GO 1.2.2 binary (as 1.3 is the only available in sid ... and 1.3 isn't OK with SSL Certs cf. https://github.com/elasticsearch/logstash-forwarder/pull/217)
+RUN wget -q "http://golang.org/dl/go1.2.2.linux-amd64.tar.gz" -O /tmp/go.tar.gz
+RUN cd /tmp && tar zxvf go.tar.gz && mv /tmp/go /opt/go 
+#a bit of cleanup
+RUN rm /tmp/go.tar.gz 
 
 # clone logstash-forwarder
 RUN git clone git://github.com/elasticsearch/logstash-forwarder.git /tmp/logstash-forwarder
-RUN cd /tmp/logstash-forwarder && git checkout v0.3.1 && go build
+RUN cd /tmp/logstash-forwarder && git checkout v0.3.1 && export GOROOT=/opt/go && /opt/go/bin/go build
 
 # Install fpm
 RUN gem install fpm
 
 # Build deb
-RUN cd /tmp/logstash-forwarder && make deb
+RUN cd /tmp/logstash-forwarder && export GOROOT=/opt/go && export PATH=$PATH:$GOROOT/bin && make deb
 RUN dpkg -i /tmp/logstash-forwarder/*.deb
 
 # Cleanup
 RUN rm -rf /tmp/*
 
 # Add FIFO
-RUN mkdir /tmp/feeds/ && mkfifo /tmp/feeds/fifofeed
+#RUN mkdir /tmp/feeds/ && mkfifo /tmp/feeds/fifofeed
 
 ADD run.sh /usr/local/bin/run.sh
 RUN chmod 755 /usr/local/bin/run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN dpkg -i /tmp/logstash-forwarder/*.deb
 RUN rm -rf /tmp/*
 
 # Add FIFO
-#RUN mkdir /tmp/feeds/ && mkfifo /tmp/feeds/fifofeed
+RUN mkdir /tmp/feeds/ && mkfifo /tmp/feeds/fifofeed
 
 ADD run.sh /usr/local/bin/run.sh
 RUN chmod 755 /usr/local/bin/run.sh

--- a/run.sh
+++ b/run.sh
@@ -11,8 +11,8 @@ cat << EOF > /tmp/config.json
   },
   "files": [
     {
-      "paths": [ "/dev/log" ],
-      "fields": { "type": "devlog" }
+      "paths": [ "/tmp/feeds/fifofeed" ],
+      "fields": { "type": "stdin" }
     }
   ]
 }

--- a/run.sh
+++ b/run.sh
@@ -11,11 +11,11 @@ cat << EOF > /tmp/config.json
   },
   "files": [
     {
-      "paths": [ "/tmp/feeds/fifofeed" ],
-      "fields": { "type": "stdin" }
+      "paths": [ "/dev/log" ],
+      "fields": { "type": "devlog" }
     }
   ]
 }
 EOF
 
-/opt/logstash-forwarder/bin/logstash-forwarder -config /tmp/config.json
+/opt/lumberjack/bin/lumberjack -config /tmp/config.json


### PR DESCRIPTION
The last pull request I made did make the docker build work .... however, after building the logstash forwarder did not work (unable to connect to the logstash instance) because of the version of the go compiler Debian provides.

The container started nicely, but when trying to connect to the logstash container the tls handshake began shouting :
```
2014/07/03 16:00:17.842093 Connecting to x.x.x.x:5043
2014/07/03 16:00:17.842448 Failed to tls handshake with x.x.x.x:5043 tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config
```
You Can check issues such as https://github.com/elasticsearch/logstash-forwarder/pull/217 to see part of the problem.

You'll understand (like I did) that for the TLS to work, currently logstash-forwarder NEEDS goland >1.1 and <1.3 ... therefore 1.2.x ... however debian does not provide this version anymore ...

So I changed the Dockerfile to download the binary tar.gz of the go 1.2.2 compiler, made a few changes to take this into account and ... there we go ;)
